### PR TITLE
Add instructions on using with Leiningen 2; add pointer to information on how to publish a fork to Clojars

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,48 @@ You will also need to manually add the checked-out project's
 dependencies as your own (the plugin simply checks out the code, it
 doesn't recursively resolve dependencies).
 
+Leiningen 2
+-----------
 
+If you're using Leiningen 2, the setup is slightly different. You must
+use the `:plugins` key rather than `:dev-dependencies`, and the
+`:extra-classpath-dirs` setting is no longer supported. As a
+workaround, you can add your library's source directory with
+`:source-paths`:
+
+      :plugins [[lein-git-deps "0.0.1-SNAPSHOT"]]
+      :git-dependencies [["https://github.com/tobyhede/monger.git"]]
+      :source-paths [".lein-git-deps/monger/src/"]
+
+
+Emacs / clojure-jack-in
+-----------------------
+
+For Emacs users, using `M-x clojure-jack-in` does not currently
+download the Git dependencies as it does normal dependencies. You must
+manually run `lein git-deps` from the command line in your project
+directory to get the Git dependencies installed.
+
+Deploying your own fork
+-----------------------
+
+Using Git-based dependencies is rather fragile and only really
+suitable for development. The code you're pulling from GitHub can
+change at any time, without warning. If you're deploying code to
+production or releasing it publicly, it's better to base your code on
+a stable known-target release. Getting the upstream maintainer of the
+original library is best, but this is not always possible if the
+original author is not around or if the project has a slow release
+cycle.
+
+In the case where pushing an updated version of the mainline release
+is not possible, fork the project and package up your own
+release. Then, you can either deploy it on your local system with
+`lein install`, create a private Maven repository and publish it
+there, or publish it to Clojars with a different group-id.
+
+Detailed instructions on how to do these things can be found at
+[https://github.com/technomancy/leiningen/blob/stable/doc/DEPLOY.md](https://github.com/technomancy/leiningen/blob/stable/doc/DEPLOY.md).
 
 ## License
 


### PR DESCRIPTION
The given instructions don't work with Lein 2; added info on how to use it with Lein 2.

Also added information on how to deploy your own stable fork to Clojars or to a private repo as an alternative to using lein-git-deps, which creates fragile dependencies.
