### PR TITLE
Update source-paths, dependencies, and repos automatically

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,8 @@
-/pom.xml
 *jar
-/lib
-/classes
-/native
-/.lein-failures
+/.lein-*
 /checkouts
-/.lein-deps-sum
+/classes
+/lib
+/native
+/pom.xml
+/target

--- a/README.md
+++ b/README.md
@@ -24,9 +24,11 @@ To get the system to play nice with leiningen, you will need to add
 lein-git-deps as a dev-dependency, specify your git-dependencies, and
 then add the Git-sourced code to to the classpath:
 
-    :dev-dependencies [[lein-git-deps "0.0.1-SNAPSHOT"]]
-    :git-dependencies [["https://github.com/tobyhede/monger.git"]]
-    :extra-classpath-dirs [".lein-git-deps/monger/src/"]
+```clojure
+:dev-dependencies [[lein-git-deps "0.0.1-SNAPSHOT"]]
+:git-dependencies [["https://github.com/tobyhede/monger.git"]]
+:extra-classpath-dirs [".lein-git-deps/monger/src/"]
+```
 
 You will also need to manually add the checked-out project's
 dependencies as your own (the plugin simply checks out the code, it
@@ -41,10 +43,10 @@ use the `:plugins` key rather than `:dev-dependencies`, and the
 workaround, you can add your library's source directory with
 `:source-paths`:
 
-      :plugins [[lein-git-deps "0.0.1-SNAPSHOT"]]
-      :git-dependencies [["https://github.com/tobyhede/monger.git"]]
-      :source-paths [".lein-git-deps/monger/src/"]
-
+```clojure
+:plugins [[lein-git-deps "0.0.1-SNAPSHOT"]]
+:git-dependencies [["https://github.com/tobyhede/monger.git"]]
+```
 
 Emacs / clojure-jack-in
 -----------------------

--- a/src/lein_git_deps/plugin.clj
+++ b/src/lein_git_deps/plugin.clj
@@ -2,3 +2,4 @@
   (:require [leiningen.git-deps :as git-deps]))
 
 (def hooks git-deps/hooks)
+(def middleware git-deps/middleware)

--- a/src/lein_git_deps/plugin.clj
+++ b/src/lein_git_deps/plugin.clj
@@ -1,0 +1,4 @@
+(ns lein-git-deps.plugin
+  (:require [leiningen.git-deps :as git-deps]))
+
+(def hooks git-deps/hooks)

--- a/src/leiningen/git_deps.clj
+++ b/src/leiningen/git_deps.clj
@@ -124,7 +124,7 @@
         (git-clone dep-url clone-dir-name git-deps-dir))
       (git-checkout commit clone-dir)
       (git-submodule-init clone-dir)
-      (git-submodule-update))))
+      (git-submodule-update clone-dir))))
 
 (hooke/add-hook #'deps/deps (fn [task & args]
                               (apply task args)

--- a/src/leiningen/git_deps.clj
+++ b/src/leiningen/git_deps.clj
@@ -126,6 +126,8 @@
       (git-submodule-init clone-dir)
       (git-submodule-update clone-dir))))
 
-(hooke/add-hook #'deps/deps (fn [task & args]
-                              (apply task args)
-                              (git-deps (first args))))
+(defn hooks
+  []
+  (hooke/add-hook #'deps/deps (fn [task & args]
+                                (apply task args)
+                                (git-deps (first args)))))

--- a/src/leiningen/git_deps.clj
+++ b/src/leiningen/git_deps.clj
@@ -95,15 +95,17 @@
   "Return a map of the project's git dependencies."
   [project]
   (map (fn [dep]
-      (let [[dep-url commit {clone-dir-name :dir}] dep
+      (let [[dep-url commit {clone-dir-name :dir src :src}] dep
             commit (or commit "master")
             clone-dir-name (or clone-dir-name (default-clone-dir dep-url))
-            clone-dir (io/file git-deps-dir clone-dir-name)]
+            clone-dir (io/file git-deps-dir clone-dir-name)
+            src (or src "src")]
         {:dep dep
          :dep-url dep-url
          :commit commit
          :clone-dir-name clone-dir-name
-         :clone-dir clone-dir}))
+         :clone-dir clone-dir
+         :src src}))
     (:git-dependencies project)))
 
 (defn git-deps
@@ -122,9 +124,11 @@
                         \"329708b\"]
 
                        ;; Third form: A URL, a commit, and a map
+                       ;; all keys in the map are optional
                        [\"https://github.com/foo/quux.git\"
                         \"some-branch\"
-                        {:dir \"alternate-directory\"}]]
+                        {:dir \"alternate-directory-to-clone-to\"
+                         :src \"alternate-src-directory-within-repo\"}]]
 "
   [project]
   (when-not (directory-exists? git-deps-dir)
@@ -147,7 +151,7 @@
 
 (defn- add-source-paths
   [project dep]
-  (let [dep-src (-> dep :clone-dir .getAbsolutePath (str "/src"))]
+  (let [dep-src (-> dep :clone-dir .getAbsolutePath (str "/" (:src dep)))]
     (update-in project [:source-paths] conj dep-src)))
 
 (defn- add-dependencies

--- a/src/leiningen/git_deps.clj
+++ b/src/leiningen/git_deps.clj
@@ -156,10 +156,14 @@
 
 (defn- add-dependencies
   [project dep]
-  (let [dep-proj-path (-> dep :clone-dir .getAbsolutePath (str "/project.clj"))
-        dep-proj (lein-project/read dep-proj-path)
-        dep-deps (:dependencies dep-proj)]
-    (update-in project [:dependencies] #(apply conj % dep-deps))))
+  (let [dep-proj-path (-> dep :clone-dir .getAbsolutePath (str "/project.clj"))]
+    (try
+      (let [dep-proj (lein-project/read dep-proj-path)
+            dep-deps (:dependencies dep-proj)]
+        (update-in project [:dependencies] #(apply conj % dep-deps)))
+      (catch Exception ex
+        (println "Could not read git-dep's project:" dep-proj-path)
+        project))))
 
 (defn middleware
   [project]

--- a/src/leiningen/git_deps.clj
+++ b/src/leiningen/git_deps.clj
@@ -78,7 +78,7 @@
         current-branch (first (filter #(.startsWith % "*") lines))]
     (when-not current-branch
       (throw (Exception. "Unable to determine current branch")))
-    (= current-branch "* (no branch)")))
+    (or (= current-branch "* (no branch)") (.startsWith current-branch "* (detached"))))
 
 (defn- git-pull
   "Run 'git-pull' in directory dir, but only if we're on a branch. If

--- a/src/leiningen/git_deps.clj
+++ b/src/leiningen/git_deps.clj
@@ -144,17 +144,22 @@
       (git-submodule-update clone-dir))))
 
 (defn hooks
+  "Called by leiningen via lein-git-deps.plugin/hooks."
   []
   (hooke/add-hook #'deps/deps (fn [task & args]
                                 (apply task args)
                                 (git-deps (first args)))))
 
 (defn- add-source-paths
+  "Given a project and a dependency map (dep), adds the dependency's
+  soure-path to the main project"
   [project dep]
   (let [dep-src (-> dep :clone-dir .getAbsolutePath (str "/" (:src dep)))]
     (update-in project [:source-paths] conj dep-src)))
 
 (defn- add-dependencies
+  "Given a project and a dependency map (dep), adds all of the dependency's
+  dependencies to the main project."
   [project dep]
   (let [dep-proj-path (-> dep :clone-dir .getAbsolutePath (str "/project.clj"))]
     (try
@@ -166,6 +171,7 @@
         project))))
 
 (defn middleware
+  "Called by leiningen via lein-git-deps.plugin/middleware."
   [project]
   (let [deps (git-dependencies project)]
     (reduce add-source-paths (reduce add-dependencies project deps) deps)))


### PR DESCRIPTION
Hi Toby,

Thank you for the great plugin.  I had a couple issues with `lein-git-deps`, though and tried to fix them in this PR.

Here is what I changed:
- It is no longer required to manually add :source-paths.  A project middleware takes care of this now
- It is no longer required to call `lein git-deps`, the repos and its dependencies will automatically be downloaded (also through the middleware)
- The hook on `lein-deps` was not working in Leinigen 2.x, I fixed that as well
- Previously Leinigen did not take over the dependency's dependencies and you had to add them manually to the parent project. This is now also fixed.

Please let me know if I should change anything in the code. I am happy to fix it if it could be more idiomatic, does not follow the proper coding style, etc.

Thanks,
Torsten
