### PR TITLE
Bump version to 0.0.2?

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ lein-git-deps as a dev-dependency, specify your git-dependencies, and
 then add the Git-sourced code to to the classpath:
 
 ```clojure
-:dev-dependencies [[lein-git-deps "0.0.1-SNAPSHOT"]]
+:dev-dependencies [[lein-git-deps "0.0.2"]]
 :git-dependencies [["https://github.com/tobyhede/monger.git"]]
 :extra-classpath-dirs [".lein-git-deps/monger/src/"]
 ```
@@ -44,7 +44,7 @@ workaround, you can add your library's source directory with
 `:source-paths`:
 
 ```clojure
-:plugins [[lein-git-deps "0.0.1-SNAPSHOT"]]
+:plugins [[lein-git-deps "0.0.2"]]
 :git-dependencies [["https://github.com/tobyhede/monger.git"]]
 ```
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject lein-git-deps "0.0.1-SNAPSHOT"
+(defproject lein-git-deps "0.0.2"
   :description "Attach git dependencies to a leiningen project"
   :eval-in-leiningen true
   :dependencies [[org.clojure/clojure "1.3.0"]])


### PR DESCRIPTION
Hi Toby,

What do you think about bumping the version to 0.0.2 and pushing a new release to Clojars?

I'd really like to use the changes from #7 but can't do so yet because the [latest version](https://clojars.org/lein-git-deps) is from 2012.

If I can help with anything just let me know. :)

Thanks,
Torsten
