### PR TITLE
add support for later git (changed `git branch ` output)

### DIFF
--- a/src/leiningen/git_deps.clj
+++ b/src/leiningen/git_deps.clj
@@ -78,7 +78,10 @@
         current-branch (first (filter #(.startsWith % "*") lines))]
     (when-not current-branch
       (throw (Exception. "Unable to determine current branch")))
-    (or (= current-branch "* (no branch)") (.startsWith current-branch "* (detached"))))
+    (or
+      (= current-branch "* (no branch)")
+      (.startsWith current-branch "* (detached")
+      (.startsWith current-branch "* (HEAD detached"))))
 
 (defn- git-pull
   "Run 'git-pull' in directory dir, but only if we're on a branch. If


### PR DESCRIPTION
Later versions of Git (2.3+, it would appear) changed the output of `git branch --no-color`

before:

```
* (detached at v0.0.14)
```

after:

```
* (HEAD detached at v0.0.14)
```

this PR adds another condition to the `detached-head?` fn to ensure the correct result is returned when git's output is different than expected.
